### PR TITLE
Performance: Implement rate-limited logger with circular buffer

### DIFF
--- a/MyUI.lua
+++ b/MyUI.lua
@@ -191,8 +191,7 @@ function addon.FocusManager:SetFocus(frame)
             windowInfo.pixelMeter:SyncStrataWithParent()
         end
         
-        addon:Debug("FocusManager: %s focused, boosted to level %d", 
-            frame:GetName() or "Unknown", boostedLevel)
+        -- Removed: Focus boost logging was spammy during window interaction
     end
 end
 

--- a/src/core/MySimpleCombatDetector.lua
+++ b/src/core/MySimpleCombatDetector.lua
@@ -599,9 +599,7 @@ function MySimpleCombatDetector:ProcessCombatEvent(...)
         end
     end
     
-    -- Log recording with GUID info for debugging
-    debugPrint("RECORD: %s (%s -> %s)", 
-        eventType, sourceName or "nil", destName or "nil")
+    -- Removed: Per-event debug logging caused massive spam
     
     -- Update activity time for relevant events (optimized with cached GUIDs)
     if sourceGUID == playerGUID then
@@ -614,21 +612,16 @@ function MySimpleCombatDetector:ProcessCombatEvent(...)
     local relativeTime = 0
     if addon.MyTimestampManager then
         relativeTime = addon.MyTimestampManager:GetRelativeTime(timestamp)
-        -- Debug: Log the timestamp calculation
-        logger:Debug("ProcessCombatEvent: timestamp=%.3f, relativeTime=%.3f", 
-            tonumber(timestamp) or 0, tonumber(relativeTime) or 0)
     else
         -- Fallback to manual calculation
         relativeTime = timestamp and combatStartTime and (timestamp - combatStartTime) or 0
-        logger:Debug("ProcessCombatEvent: FALLBACK timestamp=%.3f, combatStartTime=%.3f, relativeTime=%.3f", 
-            tonumber(timestamp) or 0, tonumber(combatStartTime) or 0, tonumber(relativeTime) or 0)
     end
     
     -- Check if we need to create a new segment
     if self:ShouldCreateNewSegment() then
         self:FinalizeCurrentSegment()
         currentSegment = self:CreateNewSegment()
-        debugPrint("Created new segment: %s", currentSegment and currentSegment.id or "failed")
+        -- Segment creation already logged in CreateNewSegment() function
     end
     
     -- Store event data using table pool for efficiency
@@ -644,10 +637,7 @@ function MySimpleCombatDetector:ProcessCombatEvent(...)
         table.insert(currentSegment.events, eventData)
         currentSegment.eventCount = currentSegment.eventCount + 1
         
-        -- Only show segment count every 10 events to reduce spam
-        if currentSegment.eventCount % 10 == 0 then
-            debugPrint("Segment %s: %d events", currentSegment.id, currentSegment.eventCount)
-        end
+        -- Removed: Even throttled segment counting caused spam during intense combat
     end
     
     -- Also add to main session events for backward compatibility during transition

--- a/src/core/MyTimestampManager.lua
+++ b/src/core/MyTimestampManager.lua
@@ -100,14 +100,12 @@ function MyTimestampManager:GetRelativeTime(inputTimestamp)
         -- Convert using the established offset
         local relativeTime = inputTimestamp - (timestampData.combatStartTime + timestampData.logTimeOffset)
         
-        logger:Trace("TimestampManager: LogTime %.3f - Offset %.3f = Relative %.3f", 
-            inputTimestamp, (timestampData.combatStartTime + timestampData.logTimeOffset), relativeTime)
+        -- Removed: Per-event trace logging caused massive spam
         return relativeTime
     else
         -- This is already a GetTime() timestamp
         local relativeTime = inputTimestamp - timestampData.combatStartTime
-        logger:Trace("TimestampManager: GetTime %.3f -> Relative %.3f", 
-            inputTimestamp, relativeTime)
+        -- Removed: Per-event trace logging caused massive spam
         return relativeTime
     end
 end
@@ -181,8 +179,7 @@ function MyTimestampManager:ValidateTimestamp(inputTimestamp, expectedRange)
         isValid = isValid and relativeTime >= expectedRange.min and relativeTime <= expectedRange.max
     end
     
-    logger:Trace("TimestampManager: Validation - Input: %.3f, Relative: %.3f, Valid: %s", 
-        inputTimestamp, relativeTime, tostring(isValid))
+    -- Removed: Per-event validation trace caused massive spam
     
     return isValid, relativeTime
 end

--- a/src/utils/VirtualScrollMixin.lua
+++ b/src/utils/VirtualScrollMixin.lua
@@ -68,7 +68,7 @@ function VirtualScrollMixin:Initialize(frame, scrollFrame, editBox, config)
     -- Set up scroll monitoring
     self:SetupScrollMonitoring()
     
-    addon:Debug("VirtualScrollMixin initialized for %s", frame:GetName() or "Unknown")
+    -- Initialization complete (removed debug spam)
 end
 
 -- Merge configuration tables
@@ -237,7 +237,7 @@ function VirtualScrollMixin:DisplayTraditional(contentLines, headerLines, footer
     self.editBox:SetText(fullContent)
     self.editBox:SetHeight(#allLines * self.config.LINE_HEIGHT)
     
-    addon:Debug("Traditional display: %d total lines", #allLines)
+    -- Removed: This was causing logging recursion in MyLoggerWindow
 end
 
 -- Handle scroll position changes


### PR DESCRIPTION
## Summary
Major performance improvements to the MyLogger system that eliminate spam and prevent UI stalls during high-volume logging periods.

### Key Changes

**🔧 Rate-Limited Circular Buffer System**
- Implement 2000-entry circular buffer with overflow handling  
- Hard 1Hz refresh limit prevents UI stalls during combat
- Lag detection with automatic tail mode fallback
- Memory-bounded design prevents runaway growth

**🚫 Combat Event Spam Elimination**
- Remove per-event debug logging from combat detector (was logging every damage/heal/spell)
- Remove per-event trace logging from timestamp manager
- Remove VirtualScrollMixin display logging recursion
- Remove duplicate segment creation messages

**⚔️ Combat Auto-Pause Removal**
- Disable automatic logger pause during combat
- Logger now works continuously with rate limiting protection
- Manual pause still available for users who want it

**🛠️ Memory Management Tools**
- Add `/myui memory` command with detailed buffer statistics
- Add `/myui gc` command for manual garbage collection
- Remove focus manager spam during window interaction

### Performance Impact
- **Before**: Logger could receive 100+ messages per second during combat, causing UI freezes
- **After**: All messages buffered off-screen, UI updates max 1/second, no performance impact

### User Experience
- Clean logs showing only system events (combat start/end, session creation, errors)
- Real-time visibility during combat without interruption
- Memory usage monitoring and control
- No more logging recursion or spam

## Test plan
- [x] Test high-volume combat scenarios - no UI stalls
- [x] Verify logger shows appropriate system messages only
- [x] Test `/myui memory` and `/myui gc` commands
- [x] Confirm circular buffer overflow handling works
- [x] Verify manual pause/resume still functions
- [x] Test buffer lag detection and tail mode

🤖 Generated with [Claude Code](https://claude.ai/code)